### PR TITLE
Fix broken demo-app link in docs

### DIFF
--- a/source/rtd_pages/lightclient_support.rst
+++ b/source/rtd_pages/lightclient_support.rst
@@ -31,7 +31,7 @@ We maintain a SDK that allows for wallet functionalities (address management, se
 **Resources**
 
 * `Android SDK source code <https://github.com/zcash/zcash-android-wallet-sdk>`_
-* `Android Demo app <https://github.com/zcash/zcash-android-wallet-sdk/tree/master/samples/demo-app>`_ 
+* `Android Demo app <https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/tree/main/demo-app>`_
 *  `Android API docs <../android/zcash-android-wallet-sdk/index.html>`_ 
 
  


### PR DESCRIPTION
This was a broken link in the docs.

I also noticed all the demo-app fragments are broken here, https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/tree/main/demo-app which would be another PR.